### PR TITLE
Add option `withDockerEvents`

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Several options are allowed after the api key.
    [-h HOSTNAME (default "api.logmatic.io")] [-p PORT (default "10514")]
    [--matchByImage REGEXP] [--matchByName REGEXP]
    [--skipByImage REGEXP] [--skipByName REGEXP]
+   [--withDockerEvents [BOOLEAN] (default true)]
 ```
 
 ## Add extra attributes
@@ -36,6 +37,10 @@ You can add extra attributes to all the pushed entries by chaining the option "-
 If you don't want all your containers to send log entries to Logmatic.io you can user the options `--matchByImage`, `--matchByName`, `--skipByImage` or `--skipByName`.
 
 However, use one inclusion/exclusion policy as these options cannot live together.
+
+## Send Docker events
+
+By default, [Docker events](#the-docker-events) are sent to Logmatic.io, but you can use the option `--withDockerEvents` and set it to `false` if you decide not to send them.
 
 # What are the data types sent to Logmatic.io?
 

--- a/index.js
+++ b/index.js
@@ -20,12 +20,13 @@ function parseOptions(){
                 '   [-a ATTR (eg myattribute="my attribute")]\n' +
                 '   [-h HOSTNAME (default "api.logmatic.io")] [-p PORT (default "10514")]\n' +
                 '   [--matchByImage REGEXP] [--matchByName REGEXP]\n' +
-                '   [--skipByImage REGEXP] [--skipByName REGEXP]')
+                '   [--skipByImage REGEXP] [--skipByName REGEXP]\n' +
+                '   [--withDockerEvents [BOOLEAN] (default true)]')
     process.exit(1);
   }
 
   var opts = minimist(process.argv.slice(3),{
-              boolean: ["debug"],
+              boolean: ["debug", "withDockerEvents"],
               alias: {
                 attr: "a",
                 host: "h",
@@ -35,7 +36,8 @@ function parseOptions(){
                 newline: true,
                 host: 'api.logmatic.io',
                 port: '10514',
-                apiKey: apiKey
+                apiKey: apiKey,
+                withDockerEvents: true
               }
             });
 
@@ -102,9 +104,12 @@ function start() {
   loghose.pipe(filter);
   streamsOpened++;
 
-  var dockerEvents = eventsFactory(opts);
-  dockerEvents.pipe(filter);
-  streamsOpened++;
+  var dockerEvents = null;
+  if (opts.withDockerEvents) {
+    dockerEvents = eventsFactory(opts);
+    dockerEvents.pipe(filter);
+    streamsOpened++;
+  }
 
   pipe();
 


### PR DESCRIPTION
I thought it could be useful to be able to specify if Docker events should be sent or not, for example if several instances of `logmatic-docker` are running, the same Docker events would be sent multiple times.
It also helps to reduce the logging volume, if you simply don't care about the Docker events :)
