### PR TITLE
allow container stats to be published

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,17 +21,14 @@ Several options are allowed after the api key.
 
 ```
 > logmatic-docker [apiKey]
-   [--stats] [-i statsInterval]
    [-a ATTR (eg myattribute="my attribute")] //Several times ok
    [-h HOSTNAME (default "api.logmatic.io")] [-p PORT (default "10514")]
    [--matchByImage REGEXP] [--matchByName REGEXP]
    [--skipByImage REGEXP] [--skipByName REGEXP]
+   [--no-events]
+   [--no-stats] [-i SECONDS (default 30s)]
 ```
 
-## Enable docker container stats
-
-You can enable container stats for each container using `--stats` and `-i statsInterval` (set to
-30 seconds by default).
 
 ## Add extra attributes
 
@@ -42,6 +39,17 @@ You can add extra attributes to all the pushed entries by chaining the option "-
 If you don't want all your containers to send log entries to Logmatic.io you can user the options `--matchByImage`, `--matchByName`, `--skipByImage` or `--skipByName`.
 
 However, use one inclusion/exclusion policy as these options cannot live together.
+
+
+## Disable docker container stats
+
+You can disable container stats for each container using `--no-stats`. You can also set the interval with `-i statsInterval` (set to
+30 seconds by default).
+
+
+## Disable docker events
+
+You can disable container events for each container using `--no-events`
 
 # What are the data types sent to Logmatic.io?
 

--- a/README.md
+++ b/README.md
@@ -21,11 +21,17 @@ Several options are allowed after the api key.
 
 ```
 > logmatic-docker [apiKey]
+   [--stats] [-i statsInterval]
    [-a ATTR (eg myattribute="my attribute")] //Several times ok
    [-h HOSTNAME (default "api.logmatic.io")] [-p PORT (default "10514")]
    [--matchByImage REGEXP] [--matchByName REGEXP]
    [--skipByImage REGEXP] [--skipByName REGEXP]
 ```
+
+## Enable docker container stats
+
+You can enable container stats for each container using `--stats` and `-i statsInterval` (set to
+30 seconds by default).
 
 ## Add extra attributes
 

--- a/index.js
+++ b/index.js
@@ -20,17 +20,18 @@ function parseOptions(){
   if(apiKey==null){
     console.log('You must define your Logmatic.io\'s api key as a first argument.\n' +
       '> logmatic-docker [apiKey] \n' +
-                '   [--stats] [-i statsInterval]\n' +
                 '   [-a ATTR (eg myattribute="my attribute")]\n' +
                 '   [-h HOSTNAME (default "api.logmatic.io")] [-p PORT (default "10514")]\n' +
                 '   [--matchByImage REGEXP] [--matchByName REGEXP]\n' +
-                '   [--skipByImage REGEXP] [--skipByName REGEXP]\n')
+                '   [--skipByImage REGEXP] [--skipByName REGEXP]\n' +
+                '   [--no-events]\n' +
+                '   [--no-stats] [-i statsInterval]\n')
 
     process.exit(1);
   }
 
   var opts = minimist(process.argv.slice(3),{
-              boolean: ["debug", "stats"],
+              boolean: ["debug", "stats", "events"],
               alias: {
                 attr: "a",
                 host: "h",
@@ -39,7 +40,8 @@ function parseOptions(){
               },
               default:{
                 newline: true,
-                stats: false,
+                stats: true,
+                events: true,
                 host: 'api.logmatic.io',
                 port: '10514',
                 apiKey: apiKey,
@@ -116,9 +118,11 @@ function start() {
       streamsOpened++;
   }
 
-  var dockerEvents = eventsFactory(opts);
-  dockerEvents.pipe(filter);
-  streamsOpened++;
+  if (opts.events) {
+      var dockerEvents = eventsFactory(opts);
+      dockerEvents.pipe(filter);
+      streamsOpened++;
+  }
 
   pipe();
 

--- a/index.js
+++ b/index.js
@@ -11,8 +11,6 @@ var statsFactory = require('docker-stats');
 var eventsFactory = require('docker-event-log');
 var minimist = require('minimist');
 
-var statsFactory = require('docker-stats');
-
 
 function parseOptions(){
   var apiKey = process.argv[2];

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "docker-allcontainers": "0.4.0",
     "docker-event-log": "0.1.3",
     "docker-loghose": "0.7.0",
+    "docker-stats": "0.5.0",
     "end-of-stream": "1.1.0",
     "through2": "2.0.0",
     "minimist": "1.2.0"


### PR DESCRIPTION
Add the possibility to published docker stats to Logmatic.io.  By default, stats are not send to Logmatic.io 

In order to enable, add `--stats` to the run command and set the interval, 30s by default, via `-i 30` option .

Local `docker build` is ok.
To test it, force the downlaod to the latest image `docker pull logmatic/logmatic-docker:latest`
