### PR TITLE
Update docker-loghose dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "docker-allcontainers": "0.4.0",
     "docker-event-log": "0.1.3",
-    "docker-loghose": "0.7.0",
+    "docker-loghose": "1.2.0",
     "docker-stats": "0.5.0",
     "end-of-stream": "1.1.0",
     "through2": "2.0.0",


### PR DESCRIPTION
logmatic-docker is currently using docker-loghose v0.7.0, which is an old release of the library (august 2015).

As docker evolved since docker-loghose v0.7.0 was released, the docker API (specifically regarding logs) has changed, and docker-loghose v0.7.0 has issues handling the new API.